### PR TITLE
ci: run publish workflow on macos-15

### DIFF
--- a/.github/workflows/publish-spm.yaml
+++ b/.github/workflows/publish-spm.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build-publish:
     name: Build, tag and create release
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: "Checkout build repo"
         uses: actions/checkout@v4


### PR DESCRIPTION
GitHub is deprecating Actions macOS 14 runners starting July 6, 2026, with full retirement on November 2, 2026, so this moves the Swift workflows to macOS 15.

https://github.com/actions/runner-images/issues/13518